### PR TITLE
Updated usage to use `render` instead of the deprecated `renderComponent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ npm install qrcode.react
 
 var React = require('react');
 var QRCode = require('qrcode.react');
-
-React.renderComponent(
+// `React.render` for `>=v0.12`,
+// otherwise use `React.renderComponent`
+React.render(
   <QRCode value="http://facebook.github.io/react/" />,
   mountNode
 );


### PR DESCRIPTION
I was slightly confused at first, so.. this *might* help peeps new to ReactJS (using `>=0.12`) :smile: 