### PR TITLE
Updated usage to use `render` instead of the deprecated `renderComponent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ npm install qrcode.react
 var React = require('react');
 var QRCode = require('qrcode.react');
 
+// `React.render` for `>=v0.12`,
+// otherwise use `React.renderComponent`
 React.renderComponent(
   <QRCode value="http://facebook.github.io/react/" />,
   mountNode


### PR DESCRIPTION
I was slightly confused at first, so.. this might help peeps new to ReactJS (using >=0.12) :smile:

Previously https://github.com/zpao/qrcode.react/pull/4.