### PR TITLE
GetDOMNode is removed from version 15 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A React component to generate [QR codes](http://en.wikipedia.org/wiki/QR_code).
 ## Installation
 
 ```sh
-npm install qrcode.react
+npm install qrcode.react.v15
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # qrcode.react
 
 A React component to generate [QR codes](http://en.wikipedia.org/wiki/QR_code).
-
+Works for React v15+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install qrcode.react.v15
 
 ```js
 var React = require('react');
-var QRCode = require('qrcode.react');
+var QRCode = require('qrcode.react.v15');
 
 React.render(
   <QRCode value="http://facebook.github.io/react/" />,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # qrcode.react
 
 A React component to generate [QR codes](http://en.wikipedia.org/wiki/QR_code).
-Works for React v15+
+
+Works with React v15+
+
 ## Installation
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "qr.js": "0.0.0"
   },
   "peerDependencies": {
-    "react": "0.12 - 0.14"
+    "react": "^0.12"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "qrcode.react",
-  "version": "0.6.0",
+  "name": "qrcode.react.v15",
+  "version": "0.7.1",
   "description": "React component to generate QR codes",
   "keywords": [
     "react",
     "react-component",
     "qrcode"
   ],
-  "homepage": "http://zpao.github.io/qrcode.react",
+  "homepage": "https://github.com/ayushya/qrcode.react",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint src/ examples/demo.js",
     "prepublish": "make clean && make all",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Paul O’Shannessy <paul@oshannessy.com>",
+  "author": "Ayushya Jaiswal <ayush0512@gmail.com> , Paul O’Shannessy <paul@oshannessy.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zpao/qrcode.react.git"
+    "url": "https://github.com/ayushya/qrcode.react.git"
   },
   "license": "ISC",
   "files": [
@@ -30,15 +30,15 @@
     "react": "0.12 - 0.14"
   },
   "devDependencies": {
-    "babel-cli": "^6.4.0",
-    "babel-eslint": "^4.1.3",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
+    "babel-cli": "^6.7.5",
+    "babel-eslint": "^4.1.8",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
-    "eslint": "^1.6.0",
-    "eslint-plugin-react": "^3.5.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.16.1",
+    "react": "^0.14.8",
+    "react-dom": "^0.14.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode.react.v15",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "React component to generate QR codes",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode.react.v15",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "React component to generate QR codes",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode.react.v15",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "React component to generate QR codes",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode.react.v15",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "React component to generate QR codes",
   "keywords": [
     "react",

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function getBackingStorePixelRatio(ctx) {
 }
 
 var getDOMNode;
-if (/^0\.14/.test(React.version)) {
+if (/^0\.14/.test(React.version) || React.version.split('.')[0] >= 15) {
   getDOMNode = (ref) => ref;
 } else {
   getDOMNode = (ref) => ref.getDOMNode();


### PR DESCRIPTION
Added Fixes for React version 15 and above.
Please update the package on NPM as well.

With your current version, we get an error if we Use React 15+
=>Error
index.js:20 Uncaught TypeError: ref.getDOMNode is not a function

![screen shot 2016-04-13 at 8 27 24 pm](https://cloud.githubusercontent.com/assets/7705367/14497920/2f634dd0-01b6-11e6-98c8-e58d791bb6d5.png)
