### PR TITLE
Changed refs to ref for setting canvas dom reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,16 +17,6 @@ function getBackingStorePixelRatio(ctx) {
   );
 }
 
-var getDOMNode;
-// Super naive semver detection but it's good enough. We support 0.12, 0.13
-// which both have getDOMNode on the ref. 0.14 and 15 make the DOM node the ref.
-var version = React.version.split(/[.-]/);
-if (version[0] === '0' && version[1] === '13' || version[1] === '12') {
-  getDOMNode = (ref) => ref.getDOMNode();
-} else {
-  getDOMNode = (ref) => ref;
-}
-
 var QRCode = React.createClass({
   propTypes: {
     value: React.PropTypes.string.isRequired,
@@ -65,7 +55,7 @@ var QRCode = React.createClass({
     qrcode.addData(value);
     qrcode.make();
 
-    var canvas = getDOMNode(this.refs.canvas);
+    var canvas = this.canvas;
 
     var ctx = canvas.getContext('2d');
     var cells = qrcode.modules;
@@ -85,13 +75,17 @@ var QRCode = React.createClass({
     });
   },
 
+  setCanvasRef(canvas) {
+    this.canvas = canvas;
+  },
+
   render: function() {
     return (
       <canvas
         style={{height: this.props.size, width: this.props.size}}
         height={this.props.size}
         width={this.props.size}
-        ref="canvas"
+        ref={this.setCanvasRef}
       />
     );
   },


### PR DESCRIPTION
I use React 15 and have: "bundle.js:8933 Uncaught Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner)" error while initialisation. This commit fixes the problem.
In the doc it also mentioned that `refs` is not deprecated but can be someday, and recommended to use `ref` with a callback.
Not sure how this effect integration with older versions.