### PR TITLE
Get parent props to allow style override

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ var QRCode = React.createClass({
   render: function() {
     return (
       <canvas
-        style={{height: this.props.size, width: this.props.size}}
+        style={Object.assign(this.props.style, {height: this.props.size, width: this.props.size})}
         height={this.props.size}
         width={this.props.size}
         ref="canvas"

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ var QRCode = React.createClass({
   render: function() {
     return (
       <canvas
-        style={Object.assign(this.props.style, {height: this.props.size, width: this.props.size})}
+        style={Object.assign({}, this.props.style, {height: this.props.size, width: this.props.size})}
         height={this.props.size}
         width={this.props.size}
         ref="canvas"


### PR DESCRIPTION
This way you can use the style attribute on the qrcode element. For example aligning the element center like this

```JS
<QRCode value={"http://google.com/"} style={{display: 'block', margin: '0 auto'}}/>
```