### PR TITLE
README: add LICENSE footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,6 @@ prop      | type                 | default value
 `level`   | `string` (`'L' 'M' 'Q' 'H'`)            | `'L'`
 
 <img src="qrcode.png" height="256" width="256">
+
+
+## LICENSE [ISC](LICENSE)


### PR DESCRIPTION
Optional,  but I've found it useful in the past for at a glance LICENSE checks