### PR TITLE
Add a new className prop into component

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ React.render(
 
 ## Available Props
 
-prop      | type                 | default value
-----------|----------------------|--------------
-`value`   | `string`             |
-`size`    | `number`             | `128`
-`bgColor` | `string` (CSS color) | `"#FFFFFF"`
-`fgColor` | `string` (CSS color) | `"#000000"`
-`level`   | `string` (`'L' 'M' 'Q' 'H'`)            | `'L'`
+prop        | type                            | default value
+------------|---------------------------------|--------------
+`className` | `string`                        | `""`
+`value`     | `string`                        | N.A
+`size`      | `number`                        | `128`
+`bgColor`   | `string` (CSS color)            | `"#FFFFFF"`
+`fgColor`   | `string` (CSS color)            | `"#000000"`
+`level`     | `string` (`"L", "M", "Q", "H"`) | `"L"`
 
 <img src="qrcode.png" height="256" width="256">
 

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -16,6 +16,7 @@ class Demo extends React.Component {
 
   update = () => {
     this.setState({
+      className: this.refs.className.value || '',
       value: this.refs.value.value || '',
       size: parseInt(this.refs.size.value) || 0,
       bgColor: this.refs.bgColor.value,
@@ -26,6 +27,7 @@ class Demo extends React.Component {
 
   render() {
     var code = `<QRCode
+  className={"${this.state.className}"}
   value={"${this.state.value}"}
   size={${this.state.size}}
   bgColor={"${this.state.bgColor}"}
@@ -34,6 +36,18 @@ class Demo extends React.Component {
 />`;
     return (
       <div>
+        <div>
+          <label>
+            ClassName:
+            <br />
+            <input
+              ref="className"
+              type="type"
+              onChange={this.update}
+              value={this.state.className}
+            />
+          </label>
+        </div>
         <div>
           <label>
             Size(px):
@@ -105,6 +119,7 @@ class Demo extends React.Component {
         </div>
 
         <QRCode
+          className={this.state.className}
           value={this.state.value}
           size={this.state.size}
           fgColor={this.state.fgColor}

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ function getBackingStorePixelRatio(ctx: CanvasRenderingContext2D): number {
 }
 
 type Props = {
+  className: string,
   value: string,
   size: number,
   level: $Keys<typeof ErrorCorrectLevel>,
@@ -38,6 +39,7 @@ class QRCode extends React.Component {
   _canvas: ?HTMLCanvasElement;
 
   static defaultProps = {
+    className: '',
     size: 128,
     level: 'L',
     bgColor: '#FFFFFF',
@@ -45,6 +47,7 @@ class QRCode extends React.Component {
   };
 
   static propTypes = {
+    className: PropTypes.string,
     value: PropTypes.string.isRequired,
     size: PropTypes.number,
     level: PropTypes.oneOf(['L', 'M', 'Q', 'H']),
@@ -112,6 +115,7 @@ class QRCode extends React.Component {
   render() {
     return (
       <canvas
+        className={this.props.className}
         style={{height: this.props.size, width: this.props.size}}
         height={this.props.size}
         width={this.props.size}


### PR DESCRIPTION
When you integrate the QRCode component in your projects sometimes you need to add CSS classes in order to be possible apply custom CSS style properties like `padding`, `margin`, etc.

Actually, my current workaround to add custom classes into the QRCode component is using a wrapper `div`, something like: 
```js
// React code
<div className="qr-code-custom-class">
    <QRCode {...props} />
</div>
```
So, I think we could add as QRCode prop the `className` attribute in order to be possible add custom classNames into the QRCode canvas.

## Demo:

![screen shot 2017-09-28 at 11 13 06](https://user-images.githubusercontent.com/7489569/30961596-97839b14-a43e-11e7-9331-084814721bfd.png)

## Linter Results:

![screen shot 2017-09-28 at 10 59 43](https://user-images.githubusercontent.com/7489569/30961600-9b359a14-a43e-11e7-8aa5-700c4c967d35.png)

## Also in this commit:

- Updated the `README.md` file in order to add the new prop in component documentation.
- Updated `demo.js` in order to be possible test the new component prop.