### PR TITLE
Ensure canvas.getContext exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class QRCodeCanvas extends React.Component<QRProps> {
     qrcode.addData(convertStr(value));
     qrcode.make();
 
-    if (this._canvas != null) {
+    if (this._canvas != null && this._canvas.getContext) {
       const canvas = this._canvas;
 
       const ctx = canvas.getContext('2d');


### PR DESCRIPTION
Ensure `getContext` function is available on the `Canvas` element so older browsers like ie8 do not break.
Since there is already a check for `this.canvas` we should also check for the getContext function since, without it, nothing can render.