### PR TITLE
Remove prop types in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lib"
   ],
   "dependencies": {
+    "loose-envify": "^1.4.0",
     "prop-types": "^15.6.0",
     "qr.js": "0.0.0"
   },
@@ -56,5 +57,10 @@
     "react-dom": "^16.2.0",
     "webpack": "^4.28.1",
     "webpack-cli": "^3.1.2"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -60,14 +60,14 @@ const DEFAULT_PROPS = {
   includeMargin: false,
 };
 
-const PROP_TYPES = {
+const PROP_TYPES = process.env.NODE_ENV !== 'production' ? {
   value: PropTypes.string.isRequired,
   size: PropTypes.number,
   level: PropTypes.oneOf(['L', 'M', 'Q', 'H']),
   bgColor: PropTypes.string,
   fgColor: PropTypes.string,
   includeMargin: PropTypes.bool,
-};
+} : {};
 
 const MARGIN_SIZE = 4;
 
@@ -132,7 +132,6 @@ class QRCodeCanvas extends React.PureComponent<QRProps> {
   _canvas: ?HTMLCanvasElement;
 
   static defaultProps = DEFAULT_PROPS;
-  static propTypes = PROP_TYPES;
 
   componentDidMount() {
     this.update();
@@ -222,9 +221,12 @@ class QRCodeCanvas extends React.PureComponent<QRProps> {
   }
 }
 
+if (process.env.NODE_ENV !== 'production') {
+  QRCodeCanvas.propTypes = PROP_TYPES;
+}
+
 class QRCodeSVG extends React.PureComponent<QRProps> {
   static defaultProps = DEFAULT_PROPS;
-  static propTypes = PROP_TYPES;
 
   render() {
     const {
@@ -271,6 +273,10 @@ class QRCodeSVG extends React.PureComponent<QRProps> {
       </svg>
     );
   }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  QRCodeSVG.propTypes = PROP_TYPES;
 }
 
 type RootProps = QRProps & {renderAs: 'svg' | 'canvas'};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,5 +12,5 @@ module.exports = {
     rules: [{test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader'}],
   },
   target: 'web',
-  mode: 'development',
+  mode: 'production',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,7 +2753,7 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==


### PR DESCRIPTION
Another piece from #49.

I decided to forgo the babel plugin because it doesn't seem to work right with babel 7. There are only two prop types so wrapping them manually is not a big deal.

Ideally - at least in theory - this would allow webpack to drop prop-types completely from a bundle if there's no other consumer of it. Even if that's not the case, it reduces bundle size a little.