### PR TITLE
Don't set height and width if the size is -1 for the svg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,11 +205,15 @@ class QRCodeSVG extends React.PureComponent<QRProps> {
       });
     });
 
+    const sizeProp = size !== -1 ? {
+      width: size,
+      height: size
+    } : {}
+
     return (
       <svg
         shapeRendering="crispEdges"
-        height={size}
-        width={size}
+        {...sizeProp}
         viewBox={`0 0 ${cells.length} ${cells.length}`}
         {...otherProps}>
         <path fill={bgColor} d={`M0,0 h${cells.length}v${cells.length}H0z`} />


### PR DESCRIPTION
For the svg, it is handy to let the svg take the size of its parent. In this case, we want to set the size to "100%" or not set the size at all.
This allow to pass -1 as a size to not set the width & height to the svg.