### PR TITLE
Add support for margin round canvas QR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ React.render(
 
 ## Available Props
 
-prop      | type                 | default value
-----------|----------------------|--------------
-`value`   | `string`             |
-`renderAs`| `string` (`'canvas' 'svg'`) | `'canvas'`
-`size`    | `number`             | `128`
-`bgColor` | `string` (CSS color) | `"#FFFFFF"`
-`fgColor` | `string` (CSS color) | `"#000000"`
-`level`   | `string` (`'L' 'M' 'Q' 'H'`)            | `'L'`
+prop            | type                 | default value
+----------------|----------------------|--------------
+`value`         | `string`             |
+`renderAs`      | `string` (`'canvas' 'svg'`) | `'canvas'`
+`size`          | `number`             | `128`
+`bgColor`       | `string` (CSS color) | `"#FFFFFF"`
+`fgColor`       | `string` (CSS color) | `"#000000"`
+`includeMargin` | `boolean`            | `false`
+`marginSize`    | `number`             | `4`
+`level`         | `string` (`'L' 'M' 'Q' 'H'`)            | `'L'`
 
 ## Custom Styles
 

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -12,6 +12,8 @@ class Demo extends React.Component {
     fgColor: '#000000',
     bgColor: '#ffffff',
     level: 'L',
+    includeMargin: false,
+    marginSize: 4,
     renderAs: 'svg',
   };
 
@@ -21,6 +23,8 @@ class Demo extends React.Component {
   size={${this.state.size}}
   bgColor={"${this.state.bgColor}"}
   fgColor={"${this.state.fgColor}"}
+  includeMargin={${this.state.includeMargin}}
+  marginSize={${this.state.marginSize}}
   level={"${this.state.level}"}
   renderAs={"${this.state.renderAs}"}
 />`;
@@ -58,6 +62,30 @@ class Demo extends React.Component {
               type="color"
               onChange={(e) => this.setState({fgColor: e.target.value})}
               value={this.state.fgColor}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Include margin:
+            <br />
+            <input
+              type="checkbox"
+              checked={this.state.includeMargin}
+              onChange={(e) => this.setState({includeMargin: e.target.checked})}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Margin size(px):
+            <br />
+            <input
+              type="number"
+              onChange={(e) =>
+                this.setState({marginSize: parseInt(e.target.value, 10) || 0})
+              }
+              value={this.state.marginSize}
             />
           </label>
         </div>
@@ -113,6 +141,8 @@ class Demo extends React.Component {
           size={this.state.size}
           fgColor={this.state.fgColor}
           bgColor={this.state.bgColor}
+          includeMargin={this.state.includeMargin}
+          marginSize={this.state.marginSize}
           level={this.state.level}
           renderAs={this.state.renderAs}
         />

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,13 +1,21 @@
 <!DOCTYPE HTML>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>QRCode.react demo</title>
-  </head>
-  <body>
-    <h1>Demo</h1>
 
-    <div id="demo"></div>
-    <script src="bundle.js"></script>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <title>QRCode.react demo</title>
+  <style>
+    body {
+      background: #ddd;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Demo</h1>
+
+  <div id="demo"></div>
+  <script src="bundle.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Adds support for drawing borders/margins round generated QR code. This change only adds this to the canvas renderer.

Related issue: https://github.com/zpao/qrcode.react/issues/48