### PR TITLE
Add support for including margin in QR Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ prop      | type                 | default value
 `bgColor` | `string` (CSS color) | `"#FFFFFF"`
 `fgColor` | `string` (CSS color) | `"#000000"`
 `level`   | `string` (`'L' 'M' 'Q' 'H'`)            | `'L'`
+`includeMargin` | `boolean`      | `false`
 
 ## Custom Styles
 

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -13,6 +13,7 @@ class Demo extends React.Component {
     bgColor: '#ffffff',
     level: 'L',
     renderAs: 'svg',
+    includeMargin: false,
   };
 
   render() {
@@ -22,6 +23,7 @@ class Demo extends React.Component {
   bgColor={"${this.state.bgColor}"}
   fgColor={"${this.state.fgColor}"}
   level={"${this.state.level}"}
+  includeMargin={${this.state.includeMargin}}
   renderAs={"${this.state.renderAs}"}
 />`;
     return (
@@ -77,6 +79,17 @@ class Demo extends React.Component {
         </div>
         <div>
           <label>
+            Include Margin:
+            <br />
+            <input
+              type="checkbox"
+              checked={this.state.includeMargin}
+              onChange={(e) => this.setState({includeMargin: e.target.checked})}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
             Render As:
             <br />
             <select
@@ -115,6 +128,7 @@ class Demo extends React.Component {
           bgColor={this.state.bgColor}
           level={this.state.level}
           renderAs={this.state.renderAs}
+          includeMargin={this.state.includeMargin}
         />
       </div>
     );


### PR DESCRIPTION
After #64, supporting margins across both renderers became super trivial. This supersedes #63, which did a bunch of math that we don't need to do anymore.

closes #48 