### PR TITLE
Add support for embedding an image into QRCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ prop      | type                 | default value
 `fgColor` | `string` (CSS color) | `"#000000"`
 `level`   | `string` (`'L' 'M' 'Q' 'H'`)            | `'L'`
 `includeMargin` | `boolean`      | `false`
+`imageSettings` | `object` (see below) |
+
+### `imageSettings`
+
+field      | type                 | default value
+-----------|----------------------|--------------
+`src`      | `string`             |
+`x`        | `number`             | none, will center
+`y`        | `number`             | none, will center
+`height`   | `number`             | 10% of `size`
+`width`    | `number`             | 10% of `size`
+`excavate` | `boolean`            | `false`
 
 ## Custom Styles
 

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -14,9 +14,28 @@ class Demo extends React.Component {
     level: 'L',
     renderAs: 'svg',
     includeMargin: false,
+    includeImage: true,
+    imageH: 24,
+    imageW: 24,
+    imageX: 0,
+    imageY: 0,
+    imageSrc: 'https://static.zpao.com/favicon.png',
+    imageExcavate: true,
+    centerImage: true,
   };
 
   render() {
+    var imageSettingsCode = this.state.includeImage
+      ? `
+  imageSettings={{
+    src: "${this.state.imageSrc}",
+    x: ${this.state.centerImage ? 'null' : this.state.imageX},
+    y: ${this.state.centerImage ? 'null' : this.state.imageY},
+    height: ${this.state.imageH},
+    width: ${this.state.imageW},
+    excavate: ${this.state.imageExcavate},
+  }}`
+      : '';
     var code = `<QRCode
   value={"${this.state.value}"}
   size={${this.state.size}}
@@ -24,7 +43,7 @@ class Demo extends React.Component {
   fgColor={"${this.state.fgColor}"}
   level={"${this.state.level}"}
   includeMargin={${this.state.includeMargin}}
-  renderAs={"${this.state.renderAs}"}
+  renderAs={"${this.state.renderAs}"}${imageSettingsCode}
 />`;
     return (
       <div>
@@ -115,9 +134,126 @@ class Demo extends React.Component {
 
         <div>
           <label>
+            Include Image:
+            <br />
+            <input
+              type="checkbox"
+              checked={this.state.includeImage}
+              onChange={(e) => this.setState({includeImage: e.target.checked})}
+            />
+          </label>
+        </div>
+
+        <fieldset disabled={!this.state.includeImage}>
+          <legend>Image Settings</legend>
+
+          <div>
+            <label>
+              Source:
+              <br />
+              <input
+                type="text"
+                onChange={(e) => this.setState({imageSrc: e.target.value})}
+                value={this.state.imageSrc}
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Image Width: {this.state.imageW}
+              <br />
+              <input
+                type="number"
+                value={this.state.imageW}
+                onChange={(e) =>
+                  this.setState({imageW: parseInt(e.target.value, 10)})
+                }
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Image Height: {this.state.imageH}
+              <br />
+              <input
+                type="number"
+                value={this.state.imageH}
+                onChange={(e) =>
+                  this.setState({imageH: parseInt(e.target.value, 10)})
+                }
+              />
+            </label>
+          </div>
+
+          <div>
+            <label>
+              Center Image:
+              <br />
+              <input
+                type="checkbox"
+                checked={this.state.centerImage}
+                onChange={(e) => this.setState({centerImage: e.target.checked})}
+              />
+            </label>
+          </div>
+          <fieldset disabled={this.state.centerImage}>
+            <legend>Image Settings</legend>
+            <div>
+              <label>
+                Image X: {this.state.imageX}
+                <br />
+                <input
+                  type="range"
+                  min={0}
+                  max={this.state.size - this.state.imageW}
+                  value={this.state.imageX}
+                  onChange={(e) =>
+                    this.setState({imageX: parseInt(e.target.value, 10)})
+                  }
+                />
+              </label>
+            </div>
+            <div>
+              <label>
+                Image Y: {this.state.imageY}
+                <br />
+                <input
+                  type="range"
+                  min={0}
+                  max={this.state.size - this.state.imageH}
+                  value={this.state.imageY}
+                  onChange={(e) =>
+                    this.setState({imageY: parseInt(e.target.value, 10)})
+                  }
+                />
+              </label>
+            </div>
+          </fieldset>
+          <div>
+            <label>
+              Excavate ("dig" foreground to nearest whole module):
+              <br />
+              <input
+                type="checkbox"
+                checked={this.state.imageExcavate}
+                onChange={(e) =>
+                  this.setState({imageExcavate: e.target.checked})
+                }
+              />
+            </label>
+          </div>
+        </fieldset>
+
+        <div>
+          <label>
             Use it:
             <br />
-            <textarea rows="6" cols="80" disabled={true} value={code} />
+            <textarea
+              rows={code.split('\n').length}
+              cols="80"
+              readOnly={true}
+              value={code}
+            />
           </label>
         </div>
 
@@ -129,6 +265,18 @@ class Demo extends React.Component {
           level={this.state.level}
           renderAs={this.state.renderAs}
           includeMargin={this.state.includeMargin}
+          imageSettings={
+            this.state.includeImage
+              ? {
+                  src: this.state.imageSrc,
+                  height: this.state.imageH,
+                  width: this.state.imageW,
+                  x: this.state.centerImage ? null : this.state.imageX,
+                  y: this.state.centerImage ? null : this.state.imageY,
+                  excavate: this.state.imageExcavate,
+                }
+              : null
+          }
         />
       </div>
     );

--- a/flow-typed/npm/qr.js_vx.x.x.js
+++ b/flow-typed/npm/qr.js_vx.x.x.js
@@ -65,7 +65,7 @@ declare module 'qr.js/lib/QRCode' {
     ): void;
     make(): void;
     addData(data: any): void;
-    modules: [[boolean]] | null;
+    modules: Array<Array<boolean>> | null;
   }
   declare module.exports: typeof QRCode;
 }


### PR DESCRIPTION
Obviously a much requested feature. I held off for so long in part because I didn't really like the options I've seen and because I haven't had the time needed to give. In particular, nothing really fits the spirit of leaving the QRCode itself as pure as possible (with modules partially obscured). I also really wanted to try to respect the error correction capacities of a QRCode and not allow images to cover more than what could be corrected, as well as not cover position and alignment markings nor timing patterns. Basically make it so that people couldn't screw it up.

I succeeded in the former (`excavate` option here), but not the latter. I'll have to settle for allowing people to shoot themselves in the foot.

Special thanks to @cssivision for opening #7 *years* ago. This was the simplest approach and I probably should have just merged this as a first step. Also to @pastleo for #72. This was much closer to what I would want but still not quite what I was looking for.