### PR TITLE
Ensure handleImageLoad() called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,6 +223,10 @@ class QRCodeCanvas extends React.PureComponent<QRProps, {imgLoaded: boolean}> {
   static defaultProps = DEFAULT_PROPS;
 
   componentDidMount() {
+    if (this._image && this._image.complete) {
+      this.handleImageLoad();
+    }
+
     this.update();
   }
 


### PR DESCRIPTION
I am running into a case where I set the `imageSettings` prop and can see my image being correctly loaded in the DOM, but QRCodeCanvas's `this.state.imgLoaded` remains `false` and the image is never drawn to the canvas. Debugging, I see that `handleImageLoad()` is never called. I suspect what is happening is something similar to this question on SO, as I am using Next.js for SSR:

https://stackoverflow.com/questions/39777833/image-onload-event-in-isomorphic-universal-react-register-event-after-image-is

Anyhow, if we call `handleImageLoad()` if the image is already loaded when the component is mounted, everything works. 