### PR TITLE
Generate as SVG with W3C valid attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -420,7 +420,7 @@ class QRCodeSVG extends React.PureComponent<QRProps> {
 
     return (
       <svg
-        shapeRendering="crispEdges"
+        shape-rendering="crispEdges"
         height={size}
         width={size}
         viewBox={`0 0 ${numCells} ${numCells}`}


### PR DESCRIPTION
The library generates QR code as SVG with `shapeRendering` attribute which fails when checked against [W3C validation](https://validator.w3.org/check), the attribute should be `shape-rendering`.