### PR TITLE
Renamed componentWillReceiveProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -231,7 +231,7 @@ class QRCodeCanvas extends React.PureComponent<QRProps, {imgLoaded: boolean}> {
     this.update();
   }
 
-  componentWillReceiveProps(nextProps) {
+  static getDerivedStateFromProps(props, state) {
     const currentSrc = this.props.imageSettings?.src;
     const nextSrc = nextProps.imageSettings?.src;
     if (currentSrc !== nextSrc) {


### PR DESCRIPTION
Replaced componentWillReceiveProps with getDerivedStateFromProps to avoid a warning appears in both production and development