### PR TITLE
Use UNSAFE_componentWillReceiveProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "qr.js": "0.0.0"
   },
   "peerDependencies": {
-    "react": "^15.5.3 || ^16.0.0 || ^17.0.0"
+    "react": "^16.3.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.14",

--- a/src/index.js
+++ b/src/index.js
@@ -231,7 +231,7 @@ class QRCodeCanvas extends React.PureComponent<QRProps, {imgLoaded: boolean}> {
     this.update();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const currentSrc = this.props.imageSettings?.src;
     const nextSrc = nextProps.imageSettings?.src;
     if (currentSrc !== nextSrc) {


### PR DESCRIPTION
This requires bumping the minimum React version for compatibility to
16.3.0, so this is not entirely backwards compatible. This will be
a quick 2.0 release.

NOTE: 2.0 will be a super short lived release, only for folks who can't necessarily go in on hooks, which will be the following release. I don't know if there's actually much of an audience there but this is for you.

Fixes #134 