### PR TITLE
Fix types to handle passing props

### DIFF
--- a/src/__test__/index.test.tsx
+++ b/src/__test__/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import {QRCodeSVG, QRCodeCanvas} from '..';
+import QRCode, {QRCodeSVG, QRCodeCanvas} from '..';
 
 const BASIC_PROPS = {
   value: 'http://picturesofpeoplescanningqrcodes.tumblr.com/',
@@ -74,4 +74,28 @@ describe('Canvas rendering', () => {
       expect(tree).toMatchSnapshot();
     }
   );
+});
+
+describe('TypeScript Support', () => {
+  test('QRCodeSVG', () => {
+    <QRCodeSVG {...BASIC_PROPS} className="foo" clipRule="bar" />;
+    expect(0).toBe(0);
+  });
+
+  test('QRCodeCanvas', () => {
+    <QRCodeCanvas {...BASIC_PROPS} className="foo" />;
+    expect(0).toBe(0);
+  });
+
+  test('QRCode', () => {
+    <QRCode {...BASIC_PROPS} renderAs="svg" className="foo" clipRule="bar" />;
+    // To ensure this is properly discriminated, add clipRule as a prop and see
+    // it fail to typecheck.
+    <QRCode {...BASIC_PROPS} renderAs="canvas" className="foo" />;
+    // Unfortunately this won't have the same typechecking because we have
+    // defaultProps.
+    <QRCode {...BASIC_PROPS} className="foo" />;
+
+    expect(0).toBe(0);
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -357,12 +357,15 @@ function QRCodeSVG(props: QRPropsSVG) {
 }
 QRCodeSVG.defaultProps = DEFAULT_PROPS;
 
-type RenderAs = 'svg' | 'canvas';
-type RootProps = QRProps & {renderAs: string};
+type RootProps =
+  | (QRPropsSVG & {renderAs: 'svg'})
+  | (QRPropsCanvas & {renderAs: 'canvas'});
 const QRCode = (props: RootProps) => {
   const {renderAs, ...otherProps} = props;
-  const Component = (renderAs as RenderAs) === 'svg' ? QRCodeSVG : QRCodeCanvas;
-  return <Component {...otherProps} />;
+  if (renderAs === 'svg') {
+    return <QRCodeSVG {...(otherProps as QRPropsSVG)} />;
+  }
+  return <QRCodeCanvas {...(otherProps as QRPropsCanvas)} />;
 };
 
 QRCode.defaultProps = {renderAs: 'canvas', ...DEFAULT_PROPS};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,8 @@ type QRProps = {
     y?: number;
   };
 };
+type QRPropsCanvas = QRProps & React.CanvasHTMLAttributes<HTMLCanvasElement>;
+type QRPropsSVG = QRProps & React.SVGProps<SVGSVGElement>;
 
 const DEFAULT_PROPS = {
   size: 128,
@@ -168,7 +170,7 @@ const SUPPORTS_PATH2D = (function () {
   return true;
 })();
 
-function QRCodeCanvas(props: QRProps) {
+function QRCodeCanvas(props: QRPropsCanvas) {
   const _canvas = useRef<HTMLCanvasElement>(null);
   const _image = useRef<HTMLImageElement>(null);
 
@@ -293,7 +295,7 @@ function QRCodeCanvas(props: QRProps) {
 }
 QRCodeCanvas.defaultProps = DEFAULT_PROPS;
 
-function QRCodeSVG(props: QRProps) {
+function QRCodeSVG(props: QRPropsSVG) {
   const {
     value,
     size,


### PR DESCRIPTION
This allows passing arbitrary props through to the underlying DOM node.
It's not perfectly compatible with the old Flow types but in line with
the previously community maintained TypeScript definition.

Fixes #186

Note: this isn't done. Need to figure out how to handle the default import component.