### PR TITLE
Fix docs `QRCodeCanvas` example.

### DIFF
--- a/examples/demo.tsx
+++ b/examples/demo.tsx
@@ -48,7 +48,7 @@ function Demo() {
 />`;
   }
   const svgCode = makeExampleCode('QRCodeSVG');
-  const canvasCode = makeExampleCode('QRCodeSVG');
+  const canvasCode = makeExampleCode('QRCodeCanvas');
 
   const renderProps = {
     value,


### PR DESCRIPTION
This should fix a minor error in example docs for `QRCodeCanvas` example in the textarea section. Cheers 😄. 