### PR TITLE
Remove default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,26 +38,11 @@ ReactDOM.render(
 );
 ```
 
-### `QRCode` - **DEPRECATED**
-
-**Note:** Usage of this is deprecated as of v3. It is available as the `default` export for compatiblity with previous versions. The `renderAs` prop is only supported with this component.
-
-```js
-import ReactDOM from 'react-dom';
-import QRCode from 'qrcode.react';
-
-ReactDOM.render(
-  <QRCode value="https://reactjs.org/" renderAs="canvas" />,
-  document.getElementById('mountNode')
-);
-```
-
 ## Available Props
 
 | prop            | type                         | default value | note |
 | --------------- | ---------------------------- | ------------- | ---- |
 | `value`         | `string`                     |
-| `renderAs`      | `string` (`'canvas' 'svg'`)  | `'canvas'`    |
 | `size`          | `number`                     | `128`         |
 | `bgColor`       | `string`                     | `"#FFFFFF"`   | CSS color |
 | `fgColor`       | `string`                     | `"#000000"`   | CSS color |

--- a/src/__test__/index.test.tsx
+++ b/src/__test__/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import QRCode, {QRCodeSVG, QRCodeCanvas} from '..';
+import {QRCodeSVG, QRCodeCanvas} from '..';
 import {describe, expect, test} from '@jest/globals';
 
 const BASIC_PROPS = {
@@ -91,18 +91,6 @@ describe('TypeScript Support', () => {
 
   test('QRCodeCanvas', () => {
     <QRCodeCanvas {...BASIC_PROPS} className="foo" />;
-    expect(0).toBe(0);
-  });
-
-  test('QRCode', () => {
-    <QRCode {...BASIC_PROPS} renderAs="svg" className="foo" clipRule="bar" />;
-    // To ensure this is properly discriminated, add clipRule as a prop and see
-    // it fail to typecheck.
-    <QRCode {...BASIC_PROPS} renderAs="canvas" className="foo" />;
-    // Unfortunately this won't have the same typechecking because we have
-    // defaultProps.
-    <QRCode {...BASIC_PROPS} className="foo" />;
-
     expect(0).toBe(0);
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -408,28 +408,4 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
   );
 });
 
-type RootProps =
-  | (QRPropsSVG & {renderAs: 'svg'})
-  | (QRPropsCanvas & {renderAs?: 'canvas'});
-const QRCode = React.forwardRef(function QRCode(
-  props: RootProps,
-  forwardedRef: React.ForwardedRef<HTMLCanvasElement | SVGSVGElement>
-) {
-  const {renderAs, ...otherProps} = props;
-  if (renderAs === 'svg') {
-    return (
-      <QRCodeSVG
-        ref={forwardedRef as React.ForwardedRef<SVGSVGElement>}
-        {...(otherProps as QRPropsSVG)}
-      />
-    );
-  }
-  return (
-    <QRCodeCanvas
-      ref={forwardedRef as React.ForwardedRef<HTMLCanvasElement>}
-      {...(otherProps as QRPropsCanvas)}
-    />
-  );
-});
-
-export {QRCode as default, QRCodeCanvas, QRCodeSVG};
+export {QRCodeCanvas, QRCodeSVG};


### PR DESCRIPTION
We've migrated to an explicit export of the SVG and Canvas components,
so no need to continue supporting this clunkier default export.