### PR TITLE
Create `ErrorCorrectionLevel` type

### DIFF
--- a/examples/full.tsx
+++ b/examples/full.tsx
@@ -1,5 +1,5 @@
-import {QRCodeSVG, QRCodeCanvas} from '..';
 import React, {useState} from 'react';
+import {ErrorCorrectionLevel, QRCodeCanvas, QRCodeSVG} from '..';
 
 function FullDemo() {
   const [value, setValue] = useState(
@@ -8,7 +8,7 @@ function FullDemo() {
   const [size, setSize] = useState(128);
   const [fgColor, setFgColor] = useState('#000000');
   const [bgColor, setBgColor] = useState('#ffffff');
-  const [level, setLevel] = useState('L');
+  const [level, setLevel] = useState<ErrorCorrectionLevel>('L');
   const [marginSize, setMarginSize] = useState(0);
   const [includeImage, setIncludeImage] = useState(true);
   const [imageH, setImageH] = useState(24);
@@ -105,7 +105,9 @@ function FullDemo() {
           <label>
             Error Level:
             <br />
-            <select onChange={(e) => setLevel(e.target.value)} value={level}>
+            <select
+              onChange={(e) => setLevel(e.target.value as ErrorCorrectionLevel)}
+              value={level}>
               <option value="L">L</option>
               <option value="M">M</option>
               <option value="Q">Q</option>

--- a/src/__test__/index.test.tsx
+++ b/src/__test__/index.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import QRCode, {QRCodeSVG, QRCodeCanvas} from '..';
+import QRCode, {QRCodeSVG, QRCodeCanvas, QRProps} from '..';
 import {describe, expect, test} from '@jest/globals';
 
-const BASIC_PROPS = {
+const BASIC_PROPS: QRProps = {
   value: 'http://picturesofpeoplescanningqrcodes.tumblr.com/',
   size: 128,
   bgColor: '#ffffff',
@@ -12,7 +12,7 @@ const BASIC_PROPS = {
   includeMargin: false,
 };
 
-const TEST_CONFIGS = [
+const TEST_CONFIGS: Partial<QRProps>[] = [
   {includeMargin: true},
   {includeMargin: false},
   {level: 'L'},

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import qrcodegen from './third-party/qrcodegen';
 
 type Modules = ReturnType<qrcodegen.QrCode['getModules']>;
 type Excavation = {x: number; y: number; w: number; h: number};
+type ErrorCorrectionLevel = 'L' | 'M' | 'Q' | 'H';
 
 const ERROR_LEVEL_MAP: {[index: string]: qrcodegen.QrCode.Ecc} = {
   L: qrcodegen.QrCode.Ecc.LOW,
@@ -30,8 +31,7 @@ type ImageSettings = {
 type QRProps = {
   value: string;
   size?: number;
-  // Should be a real enum, but doesn't seem to be compatible with real code.
-  level?: string;
+  level?: ErrorCorrectionLevel;
   bgColor?: string;
   fgColor?: string;
   style?: CSSProperties;
@@ -44,7 +44,7 @@ type QRPropsCanvas = QRProps & React.CanvasHTMLAttributes<HTMLCanvasElement>;
 type QRPropsSVG = QRProps & React.SVGAttributes<SVGSVGElement>;
 
 const DEFAULT_SIZE = 128;
-const DEFAULT_LEVEL = 'L';
+const DEFAULT_LEVEL: ErrorCorrectionLevel = 'L';
 const DEFAULT_BGCOLOR = '#FFFFFF';
 const DEFAULT_FGCOLOR = '#000000';
 const DEFAULT_INCLUDEMARGIN = false;
@@ -432,4 +432,10 @@ const QRCode = React.forwardRef(function QRCode(
   );
 });
 
-export {QRCode as default, QRCodeCanvas, QRCodeSVG};
+export {
+  QRCode as default,
+  QRCodeCanvas,
+  QRCodeSVG,
+  QRProps,
+  ErrorCorrectionLevel,
+};


### PR DESCRIPTION
The error correction prop is currently typed to accept any string. This PR narrows the type to the supported error correction levels.

I've also exported the props type so that consumers can build their props incrementally (or as they see fit), as is done in the existing tests.

Note: A "real" enum could also be used but it would mean that the enum would need to be exported and used as the prop value in every instance which I find a little more painful (and would be a breaking change for anyone with strict typing).