### PR TITLE
Add Image Opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ ReactDOM.render(
 | `height`   | `number`  | 10% of `size`     |
 | `width`    | `number`  | 10% of `size`     |
 | `excavate` | `boolean` | `false`           |
+| `opacity`  | `number`  | 1                 | 
 
 ## Custom Styles
 

--- a/examples/full.tsx
+++ b/examples/full.tsx
@@ -15,6 +15,7 @@ function FullDemo() {
   const [imageW, setImageW] = useState(24);
   const [imageX, setImageX] = useState(0);
   const [imageY, setImageY] = useState(0);
+  const [imageOpacity, setImageOpacity] = useState(1);
   const [imageSrc, setImageSrc] = useState(
     'https://static.zpao.com/favicon.png'
   );
@@ -30,6 +31,7 @@ function FullDemo() {
     y: ${centerImage ? 'undefined' : imageY},
     height: ${imageH},
     width: ${imageW},
+    opacity: ${imageOpacity},
     excavate: ${imageExcavate},
   }}`
       : '';
@@ -61,6 +63,7 @@ function FullDemo() {
           x: centerImage ? undefined : imageX,
           y: centerImage ? undefined : imageY,
           excavate: imageExcavate,
+          opacity: imageOpacity,
         }
       : undefined,
   };
@@ -185,6 +188,18 @@ function FullDemo() {
                 type="number"
                 value={imageH}
                 onChange={(e) => setImageH(parseInt(e.target.value, 10))}
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Image Opacity: {imageOpacity}
+              <br />
+              <input
+                type="number"
+                value={imageOpacity}
+                step="0.1"
+                onChange={(e) => setImageOpacity(Number(e.target.value))}
               />
             </label>
           </div>

--- a/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/__test__/__snapshots__/index.test.tsx.snap
@@ -315,6 +315,7 @@ exports[`SVG rendering renders SVG variation ({
   />
   <image
     height={5.4375}
+    opacity={1}
     preserveAspectRatio="none"
     width={5.4375}
     x={11.78125}
@@ -351,6 +352,7 @@ exports[`SVG rendering renders SVG variation ({
   />
   <image
     height={5.4375}
+    opacity={1}
     preserveAspectRatio="none"
     width={5.4375}
     x={11.78125}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -148,6 +148,7 @@ function getImageSettings(
     imageSettings.y == null
       ? cells.length / 2 - h / 2
       : imageSettings.y * scale;
+  const opacity = imageSettings.opacity == null ? 1 : imageSettings.opacity;
 
   let excavation = null;
   if (imageSettings.excavate) {
@@ -156,13 +157,6 @@ function getImageSettings(
     let ceilW = Math.ceil(w + x - floorX);
     let ceilH = Math.ceil(h + y - floorY);
     excavation = {x: floorX, y: floorY, w: ceilW, h: ceilH};
-  }
-
-  let opacity = null;
-  if (imageSettings.opacity === undefined || imageSettings.opacity === null) {
-    opacity = 1;
-  } else {
-    opacity = imageSettings.opacity;
   }
 
   return {x, y, h, w, excavation, opacity};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ type ImageSettings = {
   excavate: boolean;
   x?: number;
   y?: number;
+  opacity?: number;
 };
 
 type QRProps = {
@@ -285,6 +286,12 @@ const QRCodeCanvas = React.forwardRef(function QRCodeCanvas(
         });
       }
 
+      if (imageSettings?.opacity === undefined) {
+        ctx.globalAlpha = 1;
+      } else {
+        ctx.globalAlpha = imageSettings.opacity;
+      }
+
       if (haveImageToRender) {
         ctx.drawImage(
           image,
@@ -365,8 +372,16 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
 
   let image = null;
   if (imageSettings != null && calculatedImageSettings != null) {
+    let imageOpacity;
+
     if (calculatedImageSettings.excavation != null) {
       cells = excavateModules(cells, calculatedImageSettings.excavation);
+    }
+
+    if (imageSettings?.opacity === undefined) {
+      imageOpacity = 1;
+    } else {
+      imageOpacity = imageSettings.opacity;
     }
 
     image = (
@@ -377,6 +392,7 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
         x={calculatedImageSettings.x + margin}
         y={calculatedImageSettings.y + margin}
         preserveAspectRatio="none"
+        opacity={imageOpacity}
       />
     );
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -130,6 +130,7 @@ function getImageSettings(
   h: number;
   w: number;
   excavation: Excavation | null;
+  opacity: number;
 } {
   if (imageSettings == null) {
     return null;
@@ -157,7 +158,14 @@ function getImageSettings(
     excavation = {x: floorX, y: floorY, w: ceilW, h: ceilH};
   }
 
-  return {x, y, h, w, excavation};
+  let opacity = null;
+  if (imageSettings.opacity === undefined || imageSettings.opacity === null) {
+    opacity = 1;
+  } else {
+    opacity = imageSettings.opacity;
+  }
+
+  return {x, y, h, w, excavation, opacity};
 }
 
 function getMarginSize(includeMargin: boolean, marginSize?: number): number {
@@ -286,10 +294,8 @@ const QRCodeCanvas = React.forwardRef(function QRCodeCanvas(
         });
       }
 
-      if (imageSettings?.opacity === undefined) {
-        ctx.globalAlpha = 1;
-      } else {
-        ctx.globalAlpha = imageSettings.opacity;
+      if (calculatedImageSettings) {
+        ctx.globalAlpha = calculatedImageSettings.opacity;
       }
 
       if (haveImageToRender) {
@@ -372,16 +378,8 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
 
   let image = null;
   if (imageSettings != null && calculatedImageSettings != null) {
-    let imageOpacity;
-
     if (calculatedImageSettings.excavation != null) {
       cells = excavateModules(cells, calculatedImageSettings.excavation);
-    }
-
-    if (imageSettings?.opacity === undefined) {
-      imageOpacity = 1;
-    } else {
-      imageOpacity = imageSettings.opacity;
     }
 
     image = (
@@ -392,7 +390,7 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
         x={calculatedImageSettings.x + margin}
         y={calculatedImageSettings.y + margin}
         preserveAspectRatio="none"
-        opacity={imageOpacity}
+        opacity={calculatedImageSettings.opacity}
       />
     );
   }


### PR DESCRIPTION
Hi. I'm using the qrcode.react library well.

While using the library, I added an image to a qrcode.

However, when the size of the image I added increased, the qrcode became unreadable, so I realized it would be nice if the image had an opacity. 

Please review the pull request and let us know if you notice anything unusual. Thank you.

![스크린샷 2023-05-16 오전 2 21 40](https://github.com/zpao/qrcode.react/assets/64779472/9ef5b6be-6754-4277-9721-a4145a0ef4bf)


