### PR TITLE
Better support for dual ESM/CJS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ examples/iife/demo.js: lib/esm/index.js ${EXAMPLE_DEPS}
 	yarn run build:examples
 
 clean:
-	rm -rf lib examples/iife/demo.js
+	git clean -fX lib examples

--- a/lib/esm/package.json
+++ b/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
   "main": "./lib/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/index.js"
+    }
+  },
   "scripts": {
     "build": "yarn run build:code && yarn run build:examples",
     "build:code": "tsup src/index.tsx -d lib --format esm,cjs --dts --legacy-output --target=es2017 --platform=browser",


### PR DESCRIPTION
- Use exports field
- Ship local package.json files with `type` specified.
