### PR TITLE
Ensure displayName is correct.

### DIFF
--- a/src/__test__/index.test.tsx
+++ b/src/__test__/index.test.tsx
@@ -94,3 +94,13 @@ describe('TypeScript Support', () => {
     expect(0).toBe(0);
   });
 });
+
+describe('Display Names set', () => {
+  test('QRCodeSVG', () => {
+    expect(QRCodeSVG.displayName).toBe('QRCodeSVG');
+  });
+
+  test('QRCodeCanvas', () => {
+    expect(QRCodeCanvas.displayName).toBe('QRCodeCanvas');
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -331,6 +331,7 @@ const QRCodeCanvas = React.forwardRef(function QRCodeCanvas(
     </>
   );
 });
+QRCodeCanvas.displayName = 'QRCodeCanvas';
 
 const QRCodeSVG = React.forwardRef(function QRCodeSVG(
   props: QRPropsSVG,
@@ -407,5 +408,6 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
     </svg>
   );
 });
+QRCodeSVG.displayName = 'QRCodeSVG';
 
 export {QRCodeCanvas, QRCodeSVG};


### PR DESCRIPTION
These have mostly been subject to however esbuild decided to name
things, so they were `QRCodeSVG2` with the `forwardRef` usage. I don't
like that.
