### PR TITLE
Use React 18 rendering for the demo

### DIFF
--- a/examples/demo.tsx
+++ b/examples/demo.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import ReactDOM from 'react-dom';
+import React, {useState, StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
 import {version} from '../package.json';
 import {FullDemo} from './full';
 import {DownloadDemo} from './download';
@@ -60,4 +60,10 @@ function Demo() {
   );
 }
 
-ReactDOM.render(<Demo />, document.getElementById('demo'));
+const container = document.getElementById('demo');
+const root = createRoot(container!);
+root.render(
+  <StrictMode>
+    <Demo />
+  </StrictMode>
+);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "yarn run build:code && yarn run build:examples",
     "build:code": "tsup src/index.tsx -d lib --format esm,cjs --dts --legacy-output --target=es2017 --platform=browser",
     "build:examples": "tsup examples/demo.tsx -d examples --format iife --env.NODE_ENV production --minify --target=es2017 --legacy-output",
+    "build:examples:dev": "tsup examples/demo.tsx -d examples --format iife --env.NODE_ENV development --target=es2017 --legacy-output",
     "lint": "eslint .",
     "pretty": "prettier --write '{*,.*}.{mjs,js,json}' '**/*.{js,json}'",
     "prepack": "make clean && make all && yarn run typecheck",


### PR DESCRIPTION
This started with just using `<StrictMode>` which showed not using updated ReactDOM rendering (`createRoot`). This only works in dev mode so there's a new build command for the examples that can be used locally.