### PR TITLE
Add href attribute for QRCodeSVG

### DIFF
--- a/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/__test__/__snapshots__/index.test.tsx.snap
@@ -349,6 +349,7 @@ exports[`SVG rendering renders SVG variation ({
   />
   <image
     height={5.4375}
+    href="https://static.zpao.com/favicon.png"
     opacity={1}
     preserveAspectRatio="none"
     width={5.4375}
@@ -387,6 +388,7 @@ exports[`SVG rendering renders SVG variation ({
   />
   <image
     height={5.4375}
+    href="https://static.zpao.com/favicon.png"
     opacity={1}
     preserveAspectRatio="none"
     width={5.4375}

--- a/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/__test__/__snapshots__/index.test.tsx.snap
@@ -354,7 +354,6 @@ exports[`SVG rendering renders SVG variation ({
     preserveAspectRatio="none"
     width={5.4375}
     x={11.78125}
-    xlinkHref="https://static.zpao.com/favicon.png"
     y={11.78125}
   />
 </svg>
@@ -393,7 +392,6 @@ exports[`SVG rendering renders SVG variation ({
     preserveAspectRatio="none"
     width={5.4375}
     x={11.78125}
-    xlinkHref="https://static.zpao.com/favicon.png"
     y={11.78125}
   />
 </svg>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -435,6 +435,7 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
 
     image = (
       <image
+        href={imageSettings.src}
         xlinkHref={imageSettings.src}
         height={calculatedImageSettings.h}
         width={calculatedImageSettings.w}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -436,7 +436,6 @@ const QRCodeSVG = React.forwardRef(function QRCodeSVG(
     image = (
       <image
         href={imageSettings.src}
-        xlinkHref={imageSettings.src}
         height={calculatedImageSettings.h}
         width={calculatedImageSettings.w}
         x={calculatedImageSettings.x + margin}


### PR DESCRIPTION
[xlink:href](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) is no longer recommended. Add `href` attribute for QRCodeSVG, the deprecated `xlink:href` attribute can be used as a fallback in addition to the `href` attribute.