### PR TITLE
type(QRProps): Support string type for size

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ReactDOM.render(
 | prop            | type                         | default value | note |
 | --------------- | ---------------------------- | ------------- | ---- |
 | `value`         | `string`                     |
-| `size`          | `number`                     | `128`         |
+| `size`          | `number \| string`                     | `128`         |
 | `bgColor`       | `string`                     | `"#FFFFFF"`   | CSS color |
 | `fgColor`       | `string`                     | `"#000000"`   | CSS color |
 | `level`         | `string` (`'L' 'M' 'Q' 'H'`) | `'L'`         |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ type ImageSettings = {
 
 type QRProps = {
   value: string;
-  size?: number;
+  size?: number | string;
   level?: ErrorCorrectionLevel;
   bgColor?: string;
   fgColor?: string;


### PR DESCRIPTION
The `size` of QRProps can be used with string type '100%', would like to take this pr, thanks a lot.

![image](https://github.com/zpao/qrcode.react/assets/117748716/cdd5b9b1-550c-4007-8db5-af3d2d26a618)
