### PR TITLE
Mitigate warnings when using `QRCodeSVG` in server components

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
     "ts-jest": "^29.1.0",
     "tsup": "^8.0.2",
     "typescript": "^5.0.4"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: ISC
  */
 
-import React, {useRef, useEffect, useState, useCallback, useMemo} from 'react';
+import React from 'react';
 import type {CSSProperties} from 'react';
 import qrcodegen from './third-party/qrcodegen';
 
@@ -197,7 +197,7 @@ function useQRCode({
   imageSettings?: ImageSettings;
   size: number;
 }) {
-  let qrcode = useMemo(() => {
+  let qrcode = React.useMemo(() => {
     const segments = qrcodegen.QrSegment.makeSegments(value);
     return qrcodegen.QrCode.encodeSegments(
       segments,
@@ -206,7 +206,7 @@ function useQRCode({
     );
   }, [value, level, minVersion]);
 
-  const {cells, margin, numCells, calculatedImageSettings} = useMemo(() => {
+  const {cells, margin, numCells, calculatedImageSettings} = React.useMemo(() => {
     let cells = qrcode.getModules();
 
     const margin = getMarginSize(includeMargin, marginSize);
@@ -264,11 +264,11 @@ const QRCodeCanvas = React.forwardRef<HTMLCanvasElement, QRPropsCanvas>(
       ...otherProps
     } = props;
     const imgSrc = imageSettings?.src;
-    const _canvas = useRef<HTMLCanvasElement | null>(null);
-    const _image = useRef<HTMLImageElement>(null);
+    const _canvas = React.useRef<HTMLCanvasElement | null>(null);
+    const _image = React.useRef<HTMLImageElement>(null);
 
     // Set the local ref (_canvas) and also the forwarded ref from outside
-    const setCanvasRef = useCallback(
+    const setCanvasRef = React.useCallback(
       (node: HTMLCanvasElement | null) => {
         _canvas.current = node;
         if (typeof forwardedRef === 'function') {
@@ -281,10 +281,10 @@ const QRCodeCanvas = React.forwardRef<HTMLCanvasElement, QRPropsCanvas>(
     );
 
     // We're just using this state to trigger rerenders when images load. We
-    // Don't actually read the value anywhere. A smarter use of useEffect would
+    // Don't actually read the value anywhere. A smarter use of React.useEffect would
     // depend on this value.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [isImgLoaded, setIsImageLoaded] = useState(false);
+    const [isImgLoaded, setIsImageLoaded] = React.useState(false);
 
     const {margin, cells, numCells, calculatedImageSettings} = useQRCode({
       value,
@@ -296,7 +296,7 @@ const QRCodeCanvas = React.forwardRef<HTMLCanvasElement, QRPropsCanvas>(
       size,
     });
 
-    useEffect(() => {
+    React.useEffect(() => {
       // Always update the canvas. It's cheap enough and we want to be correct
       // with the current state.
       if (_canvas.current != null) {
@@ -370,7 +370,7 @@ const QRCodeCanvas = React.forwardRef<HTMLCanvasElement, QRPropsCanvas>(
 
     // Ensure we mark image loaded as false here so we trigger updating the
     // canvas in our other effect.
-    useEffect(() => {
+    React.useEffect(() => {
       setIsImageLoaded(false);
     }, [imgSrc]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -206,24 +206,25 @@ function useQRCode({
     );
   }, [value, level, minVersion]);
 
-  const {cells, margin, numCells, calculatedImageSettings} = React.useMemo(() => {
-    let cells = qrcode.getModules();
+  const {cells, margin, numCells, calculatedImageSettings} =
+    React.useMemo(() => {
+      let cells = qrcode.getModules();
 
-    const margin = getMarginSize(includeMargin, marginSize);
-    const numCells = cells.length + margin * 2;
-    const calculatedImageSettings = getImageSettings(
-      cells,
-      size,
-      margin,
-      imageSettings
-    );
-    return {
-      cells,
-      margin,
-      numCells,
-      calculatedImageSettings,
-    };
-  }, [qrcode, size, imageSettings, includeMargin, marginSize]);
+      const margin = getMarginSize(includeMargin, marginSize);
+      const numCells = cells.length + margin * 2;
+      const calculatedImageSettings = getImageSettings(
+        cells,
+        size,
+        margin,
+        imageSettings
+      );
+      return {
+        cells,
+        margin,
+        numCells,
+        calculatedImageSettings,
+      };
+    }, [qrcode, size, imageSettings, includeMargin, marginSize]);
 
   return {
     qrcode,


### PR DESCRIPTION
Closes #347

Before this PR, react hooks were imported as named ESM exports. This could generate bundler warnings in frameworks like Next.js:

```
 ⚠ ./node_modules/.pnpm/qrcode.react@3.1.0_react@18.3.1/node_modules/qrcode.react/lib/esm/index.js
Attempted import error: 'useRef' is not exported from 'react' (imported as 'useRef').
```

This PR replaces named imports with properties of the `default` import. This provides a sufficient workaround for now.

Going forward, we will need to split the library into separate files so that `QRCodeSVG` could be imported on its own. This will be needed when default react export is removed for tree-shaking. As of React v16...v19, both of these imports are equivalent:

```ts
import * as React from 'react';
import React from 'react'; // might not work in React v20+
```
(see [v18 typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3263bd441c7d569257435eb6759cb4bdcd09503f/types/react/index.d.ts#L46-L47) & [v19 typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3714f222ff3ab20db84a2229d5e64564e7b82932/types/react/index.d.ts#L65-L66) from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022)

Some extra context:
- https://www.epicreact.dev/importing-react-through-the-ages (November 2020)
- https://legacy.reactjs.org/docs/react-api.html (legacy docs, but still valid for 18.2.0)

I guess it’s a patch change: [v3.1.0](https://github.com/zpao/qrcode.react/releases/tag/v3.1.0) → v3.1.1.