### PR TITLE
fix: Add types to exports field in package.json to resolve type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,14 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./lib/esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
closes: #367 

![CleanShot 2024-08-28 at 16 37 34](https://github.com/user-attachments/assets/e9bb1662-28cf-4af5-80ab-0d7f31301ebe)
