### PR TITLE
Add "sideEffects: false"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       }
     }
   },
+  "sideEffects": false,
   "scripts": {
     "build": "pnpm run build:code && pnpm run build:examples",
     "build:code": "tsup src/index.tsx -d lib --format esm,cjs --dts --legacy-output --target=es2017 --platform=browser",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good for esm, modules, named imports.

ESM is how files and imports are organized, Side effects is how a bundler can remove obviously unused data from an assembly. Only both make maximum effect.

rollup https://rollupjs.org/configuration-options/#treeshake-modulesideeffects
webpack https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
esbuild https://esbuild.github.io/plugins/#on-resolve-arguments
