### PR TITLE
Allow encoding raw binary data

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,7 +73,7 @@ type QRProps = {
    * The value to encode into the QR Code. An array of strings can be passed in
    * to represent multiple segments to further optimize the QR Code.
    */
-  value: string | string[];
+  value: string | Uint8Array | (string | Uint8Array)[];
   /**
    * The size, in pixels, to render the QR Code.
    * @defaultValue 128
@@ -277,7 +277,7 @@ function useQRCode({
   size,
   boostLevel,
 }: {
-  value: string | string[];
+  value: string | Uint8Array | (string | Uint8Array)[];
   level: ErrorCorrectionLevel;
   minVersion: number;
   includeMargin: boolean;
@@ -289,7 +289,11 @@ function useQRCode({
   let qrcode = React.useMemo(() => {
     const values = Array.isArray(value) ? value : [value];
     const segments = values.reduce<qrcodegen.QrSegment[]>((accum, v) => {
-      accum.push(...qrcodegen.QrSegment.makeSegments(v));
+      const seg =
+        typeof v === 'string'
+          ? qrcodegen.QrSegment.makeSegments(v)
+          : [qrcodegen.QrSegment.makeBytes([...v])];
+      accum.push(...seg);
       return accum;
     }, []);
     return qrcodegen.QrCode.encodeSegments(


### PR DESCRIPTION
Thanks for your work on this library!

I know this isn't a common use case, but I think this is something missing here. As you know, most text is actually encoded in binary mode as UTF-8, so accepting binary input chould be the basic API.

In my case, I needed to encode over 64 bytes of binary data along with strings, and base64 adds 33% extra size and makes QR codes more complex, which can hurt scanning accuracy.

Would you consider adding support for raw byte encoding? I'd also like to keep the API simple—open to ideas on the best approach.